### PR TITLE
[GDR-2235] Adjust NEWS to Bioc format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: gDRtestData
 Title: gDRtestData - R data package with testing dose reponse data
-Version: 0.99.20
-Date: 2023-09-04
+Version: 0.99.21
+Date: 2023-09-18
 Description: R package with internal dose-response test data. Package provides functions to generate
   input testing data that can be used as the input for gDR pipeline. It also contains RDS files
   with MAE data processed by gDR.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,64 +1,67 @@
-# 0.99.20
-  - update testdata
+## 0.99.21 (2023-09-18)
+- adjust NEWS to Bioc format
 
-# 0.99.19
-  - BiocStyle added to dependency
+## 0.99.20 (2023-09-04)
+- update testdata
 
-# 0.99.18
-  - replaced rds files with qs
+## 0.99.19 (2023-06-23)
+- BiocStyle added to dependency
 
-# 0.99.17
-  - switch from merge to [[
+## 0.99.18 (2023-06-22)
+- replaced rds files with qs
 
-# 0.99.16
-  - update datasets
+## 0.99.17 (2023-06-15)
+- switch from merge to [[
 
-# 0.99.15
-  - format the vignette with BiocStyle
+## 0.99.16 (2023-05-29)
+- update datasets
 
-# 0.99.14
-  - fix related with data.table
+## 0.99.15 (2023-05-24)
+- format the vignette with BiocStyle
 
-# 0.99.13
-- Update testdata as per changes in excess assays
+## 0.99.14 (22023-05-15)
+- fix related with data.table
 
-# 0.99.12
-- Update testdata as per new data model
+## 0.99.13 (2023-05-15)
+- update testdata as per changes in excess assays
 
-# 0.99.11
-  - changed data.frame to data.table
+## 0.99.12 (2023-05-11)
+- update testdata as per new data model
+
+## 0.99.11 (2023-04-25)
+- changed data.frame to data.table
   
-# 0.99.10
-  - removing redundant files
+## 0.99.10 (2023-04-24)
+- removing redundant files
 
-# 0.99.9
-  - fix warning in Bioc check
+## 0.99.9 (2023-04-20)
+- fix warning in Bioc check
 
-# 0.99.8
-  - switch to OSI license
+## 0.99.8 (2023-04-20)
+- switch to OSI license
 
-# 0.99.7
-  - update testdata
+## 0.99.7 (2023-04-19)
+- update testdata
   
-# 0.99.6
-  - moved wrappers to gDRcore
+## 0.99.6 (2023-04-18)
+- moved wrappers to gDRcore
   
-# 0.99.5
-  - update packages version
+## 0.99.5 (2023-04-17)
+- update packages version
 
-# 0.99.4
-  - add R 4.2 as a dependency
+## 0.99.4 (2023-04-17)
+- add R 4.2 as a dependency
 
-# 0.99.3
-  - Update testdata
+## 0.99.3 (2023-04-14)
+- update testdata
 
-# 0.99.2
-  - Improve documentation (Bioc compatibility)
+## 0.99.2 (2023-04-13)
+- improve documentation (Bioc compatibility)
 
-# 0.99.1
-  - Update maintainer
+## 0.99.1 (2023-04-07)
+- update maintainer
 
-# 0.99.0
-  - Preparing package for Bioc submission
-  - fix examples
+## 0.99.0 (2023-03-31)
+- preparing package for Bioc submission
+- fix examples
   


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2235](https://jira.gene.com/jira/browse/GDR-2235)

To test: install package and run `utils::news(package = "gDRtestData")` 
You should see in help window
![gDRtestData](https://github.com/gdrplatform/gDRtestData/assets/31825957/644df8c8-07a2-445e-bd89-65a7be571d58)

NULL in console means error!

## Why was it changed?
To adjust to Bioc rules.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
